### PR TITLE
Hotfix: Remove "Warning" from routable targets

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - v*
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches:
-      - '*'
   schedule:
     - cron: '11 22 * * 1'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [v2.10.4](https://github.com/traefik/traefik/tree/v2.10.4) (2023-07-24)
+[All Commits](https://github.com/traefik/traefik/compare/v2.10.3...v2.10.4)
+
+**Bug fixes:**
+- **[acme]** Update go-acme/lego to v4.13.2 ([#10036](https://github.com/traefik/traefik/pull/10036) by [ldez](https://github.com/ldez))
+- **[acme]** Update go-acme/lego to v4.13.0 ([#10029](https://github.com/traefik/traefik/pull/10029) by [ldez](https://github.com/ldez))
+- **[k8s/ingress,k8s]** fix: avoid panic on resource backends ([#10023](https://github.com/traefik/traefik/pull/10023) by [ldez](https://github.com/ldez))
+- **[middleware,tracing,plugins]** fix: traceability of the middleware plugins ([#10028](https://github.com/traefik/traefik/pull/10028) by [ldez](https://github.com/ldez))
+
+**Documentation:**
+- Update maintainers guidelines ([#9981](https://github.com/traefik/traefik/pull/9981) by [geraldcroes](https://github.com/geraldcroes))
+- Update release documentation ([#9975](https://github.com/traefik/traefik/pull/9975) by [rtribotte](https://github.com/rtribotte))
+
+**Misc:**
+- **[webui]** Updates the Hub tooltip content using a web component and adds an option to disable Hub button ([#10008](https://github.com/traefik/traefik/pull/10008) by [mdeliatf](https://github.com/mdeliatf))
+
 ## [v2.10.3](https://github.com/traefik/traefik/tree/v2.10.3) (2023-06-17)
 [All Commits](https://github.com/traefik/traefik/compare/v2.10.2...v2.10.3)
 

--- a/go.mod
+++ b/go.mod
@@ -381,3 +381,5 @@ replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402
 // ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http in multiple modules
 // tencentcloud uses monorepo with multimodule but the go.mod files are incomplete.
 exclude github.com/tencentcloud/tencentcloud-sdk-go v3.0.83+incompatible
+
+replace github.com/traefik/traefik => ../traefik

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -120,7 +120,7 @@ func (p *Provider) keepContainer(ctx context.Context, item itemData) bool {
 		return false
 	}
 
-	if item.Status != api.HealthPassing && item.Status != api.HealthWarning {
+	if item.Status != api.HealthPassing {
 		logger.Debug("Filtering unhealthy or starting item")
 		return false
 	}


### PR DESCRIPTION
Prior to this change, Traefik was allowing both "warning" and "healthy" to be included in routes to a service. However, we rely on "warning" to be excluded as those services are not yet ready for traffic. This PR removes "warning" as a valid routable service in our fork.

We expect to correct the initial_status for services to start up with "critical", to be more align with the community, but for now, this fork will allow us to resolve blippy services without requiring every service be redeployed.

PTAL